### PR TITLE
Update nacos-quick-start.yaml

### DIFF
--- a/deploy/nacos/nacos-quick-start.yaml
+++ b/deploy/nacos/nacos-quick-start.yaml
@@ -80,6 +80,8 @@ spec:
           env:
             - name: NACOS_REPLICAS
               value: "3"
+            - name: SPRING_DATASOURCE_PLATFORM
+              value: "mysql"
             - name: MYSQL_SERVICE_HOST
               valueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
fix “nacos server did not start because dumpservice bean construction failure. errMsg102, errllsg dataSource or tableName is null”